### PR TITLE
fix: bust apk layer cache on every build to avoid stale Alpine packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,7 +339,9 @@ jobs:
           context: .
           platforms: ${{ matrix.platform.name }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: VERSION=${{ env.ZEROTIERPROXY_VERSION }}
+          build-args: |
+            VERSION=${{ env.ZEROTIERPROXY_VERSION }}
+            CACHEBUST=${{ github.run_id }}
           provenance: mode=max
           sbom: true
           outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -81,7 +81,9 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          build-args: VERSION=${{ env.ZEROTIERPROXY_VERSION }}
+          build-args: |
+            VERSION=${{ env.ZEROTIERPROXY_VERSION }}
+            CACHEBUST=${{ github.run_id }}
           push: false
           load: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,11 @@ LABEL org.opencontainers.image.title="zerotier-proxy" \
 
 COPY --from=stage /ZeroTierOne/tcp-proxy/tcp-proxy /usr/sbin
 
-RUN echo "${VERSION}" > /etc/zerotier-version \
+# The CACHEBUST echo forces a fresh apk index/upgrade on every build so
+# security fixes in Alpine's package repo aren't masked by a stale,
+# content-addressed Docker layer cache.
+RUN echo "Cache bust: ${CACHEBUST}" \
+    && echo "${VERSION}" > /etc/zerotier-version \
     && rm -rf /var/lib/zerotier-one \
     && apk --no-cache update \
     && apk --no-cache upgrade \


### PR DESCRIPTION
## Summary
- The final image stage's `apk update/upgrade/add` layer could be silently reused from a cached Docker layer even after Alpine ships a security fix for one of its packages, since the layer cache key is purely content-addressed (same base image digest + same Dockerfile text = cache hit)
- Wires up the previously-unused `CACHEBUST` build arg in the Dockerfile's final stage and passes a fresh value (`github.run_id`) from `build.yml` and `docker-scout.yml`, so that layer always re-runs `apk update` fresh on every CI build
- Verified locally: same `CACHEBUST` value hits the Docker layer cache; a different value forces `apk update/upgrade/add` to re-run, while the (expensive) ZeroTier compile stage's caching is untouched

## Test plan
- [ ] Verify CI checks pass on this PR
- [ ] Confirm the built image still runs correctly (tcp-proxy starts, healthcheck passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)